### PR TITLE
Improve `Service` traits

### DIFF
--- a/examples/colors/src/main.rs
+++ b/examples/colors/src/main.rs
@@ -32,8 +32,7 @@ fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let service = ColorService::default();
-    let server: SimpleServer<ColorService> = SimpleServer::new(service, config);
+    let server: SimpleServer<ColorService> = SimpleServer::new(ColorService::default(), config);
     server.serve().unwrap();
 }
 
@@ -45,6 +44,7 @@ const WINDOW_SECONDARY: u32 = 1;
 
 type Color = (u8, u8, u8);
 
+#[derive(Debug, Clone, Default)]
 pub struct ColorService {
     color: Color,
     prev_frame: Vec<u8>,
@@ -87,15 +87,6 @@ impl ColorService {
         self.color = Self::random_color();
         self.send_frame(messages, WINDOW_PRIMARY, self.color)?;
         Ok(())
-    }
-}
-
-impl Default for ColorService {
-    fn default() -> Self {
-        Self {
-            color: Color::default(),
-            prev_frame: Vec::new(),
-        }
     }
 }
 

--- a/examples/colors/src/main.rs
+++ b/examples/colors/src/main.rs
@@ -32,7 +32,8 @@ fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let server: SimpleServer<ColorService> = SimpleServer::new(config);
+    let service = ColorService::default();
+    let server: SimpleServer<ColorService> = SimpleServer::new(service, config);
     server.serve().unwrap();
 }
 
@@ -89,20 +90,21 @@ impl ColorService {
     }
 }
 
-impl SimpleService for ColorService {
-    fn new() -> Self {
+impl Default for ColorService {
+    fn default() -> Self {
         Self {
             color: Color::default(),
             prev_frame: Vec::new(),
         }
     }
+}
 
-    fn main(self, messages: Messages) -> Result<()> {
-        // We simply proxy to the `SimpleServiceExt` implementation.
+impl SimpleService for ColorService {
+    fn main(self, messages: Messages) -> libgsh::Result<()> {
         <Self as SimpleServiceExt>::main(self, messages)
     }
 
-    fn server_hello() -> ServerHelloAck {
+    fn server_hello(&self) -> ServerHelloAck {
         ServerHelloAck {
             format: FrameFormat::Rgba.into(),
             windows: vec![

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -46,16 +46,27 @@ async fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let service = CubeService::new();
-    let server: AsyncServer<CubeService> = AsyncServer::new(service, config);
+    let server = AsyncServer::new(CubeService::default(), config);
     server.serve().await.unwrap();
 }
 
+#[derive(Debug, Clone)]
 pub struct CubeService {
     start: Instant,
     width: usize,
     height: usize,
     // prev_frame: Vec<u8>,
+}
+
+impl Default for CubeService {
+    fn default() -> Self {
+        Self {
+            start: Instant::now(),
+            width: INITIAL_WIDTH,
+            height: INITIAL_HEIGHT,
+            // prev_frame: vec![0; INITIAL_WIDTH * INITIAL_HEIGHT * PIXEL_BYTES],
+        }
+    }
 }
 
 impl CubeService {

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -46,7 +46,8 @@ async fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let server: AsyncServer<CubeService> = AsyncServer::new(config);
+    let service = CubeService::new();
+    let server: AsyncServer<CubeService> = AsyncServer::new(service, config);
     server.serve().await.unwrap();
 }
 
@@ -189,20 +190,11 @@ impl CubeService {
 
 #[async_trait]
 impl AsyncService for CubeService {
-    fn new() -> Self {
-        Self {
-            start: Instant::now(),
-            width: INITIAL_WIDTH,
-            height: INITIAL_HEIGHT,
-            // prev_frame: Vec::new(),
-        }
-    }
-
     async fn main(self, messages: Messages) -> Result<()> {
         <Self as AsyncServiceExt>::main(self, messages).await
     }
 
-    fn server_hello() -> ServerHelloAck {
+    fn server_hello(&self) -> ServerHelloAck {
         ServerHelloAck {
             format: FrameFormat::Rgba.into(),
             windows: vec![WindowSettings {

--- a/examples/password_auth/src/main.rs
+++ b/examples/password_auth/src/main.rs
@@ -22,11 +22,11 @@ fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let service = AuthService {};
-    let server: SimpleServer<AuthService> = SimpleServer::new(service, config);
+    let server = SimpleServer::new(AuthService::default(), config);
     server.serve().unwrap();
 }
 
+#[derive(Debug, Clone, Default)]
 pub struct AuthService {}
 
 impl SimpleService for AuthService {

--- a/examples/password_auth/src/main.rs
+++ b/examples/password_auth/src/main.rs
@@ -22,23 +22,15 @@ fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let server: SimpleServer<AuthService> = SimpleServer::new(config);
+    let service = AuthService {};
+    let server: SimpleServer<AuthService> = SimpleServer::new(service, config);
     server.serve().unwrap();
 }
 
 pub struct AuthService {}
 
 impl SimpleService for AuthService {
-    fn new() -> Self {
-        Self {}
-    }
-
-    fn main(self, messages: Messages) -> libgsh::Result<()> {
-        // We simply proxy to the `SimpleServiceExt` implementation.
-        <Self as SimpleServiceExt>::main(self, messages)
-    }
-
-    fn server_hello() -> ServerHelloAck {
+    fn server_hello(&self) -> ServerHelloAck {
         ServerHelloAck {
             format: server_hello_ack::FrameFormat::Rgb.into(),
             windows: Vec::new(),
@@ -48,10 +40,15 @@ impl SimpleService for AuthService {
         }
     }
 
-    fn auth_verifier() -> Option<AuthVerifier> {
+    fn auth_verifier(&self) -> Option<AuthVerifier> {
         Some(AuthVerifier::Password(Box::new(MyPasswordVerifier {
             password: "password".to_string(),
         })))
+    }
+
+    fn main(self, messages: Messages) -> libgsh::Result<()> {
+        // We simply proxy to the `SimpleServiceExt` implementation.
+        <Self as SimpleServiceExt>::main(self, messages)
     }
 }
 

--- a/examples/password_auth/src/main.rs
+++ b/examples/password_auth/src/main.rs
@@ -22,12 +22,21 @@ fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let server = SimpleServer::new(AuthService::default(), config);
+    const PASSWORD: &str = "password";
+    let server = SimpleServer::new(AuthService::new(PASSWORD.to_string()), config);
     server.serve().unwrap();
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct AuthService {}
+#[derive(Debug, Clone)]
+pub struct AuthService {
+    password: String,
+}
+
+impl AuthService {
+    pub fn new(password: String) -> Self {
+        Self { password }
+    }
+}
 
 impl SimpleService for AuthService {
     fn server_hello(&self) -> ServerHelloAck {
@@ -42,7 +51,7 @@ impl SimpleService for AuthService {
 
     fn auth_verifier(&self) -> Option<AuthVerifier> {
         Some(AuthVerifier::Password(Box::new(MyPasswordVerifier {
-            password: "password".to_string(),
+            password: self.password.clone(),
         })))
     }
 

--- a/examples/signature_auth/src/main.rs
+++ b/examples/signature_auth/src/main.rs
@@ -28,11 +28,11 @@ fn main() {
         .with_no_client_auth()
         .with_single_cert(vec![key.cert.der().clone()], private_key)
         .unwrap();
-    let service = AuthService {};
-    let server: SimpleServer<AuthService> = SimpleServer::new(service, config);
+    let server = SimpleServer::new(AuthService::default(), config);
     server.serve().unwrap();
 }
 
+#[derive(Debug, Clone, Default)]
 pub struct AuthService {}
 
 impl SimpleService for AuthService {

--- a/libgsh/src/async/service.rs
+++ b/libgsh/src/async/service.rs
@@ -12,7 +12,7 @@ use tokio::io::AsyncWriteExt;
 /// A trait for an async service that can be run in a separate thread.
 /// The service is responsible for handling client events and sending frames to the client.
 #[async_trait]
-pub trait AsyncService: Send + Sync + 'static {
+pub trait AsyncService: Clone + Send + Sync + 'static {
     /// Initial window setting preferences for the service.\
     /// This is used in the `handshake_server` function to set the initial window settings for the client.
     /// This is optional and can be overridden by the service implementation.

--- a/libgsh/src/async/service.rs
+++ b/libgsh/src/async/service.rs
@@ -13,18 +13,15 @@ use tokio::io::AsyncWriteExt;
 /// The service is responsible for handling client events and sending frames to the client.
 #[async_trait]
 pub trait AsyncService: Send + Sync + 'static {
-    /// Creates a new instance of the service.\
-    fn new() -> Self;
-
     /// Initial window setting preferences for the service.\
     /// This is used in the `handshake_server` function to set the initial window settings for the client.
     /// This is optional and can be overridden by the service implementation.
     /// If not provided, the client may use its own default settings.
-    fn server_hello() -> ServerHelloAck;
+    fn server_hello(&self) -> ServerHelloAck;
 
     /// Auth verifier for the service.\
     /// This is used to verify the client authentication method.
-    fn auth_verifier() -> Option<AuthVerifier> {
+    fn auth_verifier(&self) -> Option<AuthVerifier> {
         None
     }
 

--- a/libgsh/src/simple/service.rs
+++ b/libgsh/src/simple/service.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 
 /// A trait for a simple service that can be run in a separate thread.
 /// The service is responsible for handling client events and sending frames to the client.
-pub trait SimpleService: Clone {
+pub trait SimpleService: Clone + Send + Sync + 'static {
     /// Initial window setting preferences for the service.\
     /// This is used in the `handshake_server` function to set the initial window settings for the client.
     /// This is optional and can be overridden by the service implementation.

--- a/libgsh/src/simple/service.rs
+++ b/libgsh/src/simple/service.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 
 /// A trait for a simple service that can be run in a separate thread.
 /// The service is responsible for handling client events and sending frames to the client.
-pub trait SimpleService {
+pub trait SimpleService: Clone {
     /// Initial window setting preferences for the service.\
     /// This is used in the `handshake_server` function to set the initial window settings for the client.
     /// This is optional and can be overridden by the service implementation.

--- a/libgsh/src/simple/service.rs
+++ b/libgsh/src/simple/service.rs
@@ -11,17 +11,15 @@ use std::io::Write;
 /// A trait for a simple service that can be run in a separate thread.
 /// The service is responsible for handling client events and sending frames to the client.
 pub trait SimpleService {
-    fn new() -> Self;
-
     /// Initial window setting preferences for the service.\
     /// This is used in the `handshake_server` function to set the initial window settings for the client.
     /// This is optional and can be overridden by the service implementation.
     /// If not provided, the client may use its own default settings.
-    fn server_hello() -> ServerHelloAck;
+    fn server_hello(&self) -> ServerHelloAck;
 
     /// Auth verifier for the service.\
     /// This is used to verify the client authentication method.
-    fn auth_verifier() -> Option<AuthVerifier> {
+    fn auth_verifier(&self) -> Option<AuthVerifier> {
         None
     }
 


### PR DESCRIPTION
This pull request refactors the service initialization and handling mechanism across both the `SimpleServer` and `AsyncServer` implementations. It removes the static `new` method from service traits, introduces service instances as parameters to the server constructors, and updates the service traits to use instance methods for better flexibility and state management. Additionally, it updates example implementations to align with these changes.

### Server Refactor and Trait Updates:

* `libgsh/src/async/server.rs`:
  - Replaced the static `new` method in `AsyncService` with an instance-based approach, requiring a `service` parameter in `AsyncServer::new`. Updated `handle_client` to use the service instance for `server_hello` and `auth_verifier`. ([[1]](diffhunk://#diff-ae984f86d6d4c462f63b2b929597502b73ad1f54f12663bfc1548ad88e3b63d0L26-R26), [[2]](diffhunk://#diff-ae984f86d6d4c462f63b2b929597502b73ad1f54f12663bfc1548ad88e3b63d0L36-R38), [[3]](diffhunk://#diff-ae984f86d6d4c462f63b2b929597502b73ad1f54f12663bfc1548ad88e3b63d0R67-R71), [[4]](diffhunk://#diff-ae984f86d6d4c462f63b2b929597502b73ad1f54f12663bfc1548ad88e3b63d0L80-R86), [[5]](diffhunk://#diff-ae984f86d6d4c462f63b2b929597502b73ad1f54f12663bfc1548ad88e3b63d0L98))
* `libgsh/src/simple/server.rs`:
  - Similar changes were applied to `SimpleServer`, with the `service` parameter replacing the static `new` method. Updated `handle_client` to use instance methods for `server_hello` and `auth_verifier`. ([[1]](diffhunk://#diff-a9ada463ab6e690100123bc6b545d1c43fa10763c32867ab789996c525838586L22-R31), [[2]](diffhunk://#diff-a9ada463ab6e690100123bc6b545d1c43fa10763c32867ab789996c525838586R59-R64), [[3]](diffhunk://#diff-a9ada463ab6e690100123bc6b545d1c43fa10763c32867ab789996c525838586L73-R79), [[4]](diffhunk://#diff-a9ada463ab6e690100123bc6b545d1c43fa10763c32867ab789996c525838586L90))

### Service Trait Enhancements:

* `libgsh/src/async/service.rs`:
  - Removed the static `new` method from `AsyncService` and added `Clone` as a required trait. Updated `server_hello` and `auth_verifier` to instance methods. ([libgsh/src/async/service.rsL15-R24](diffhunk://#diff-7783d44daf0df973d3d3c0f6fbb8105afb8ab460c78c0c0308c9b25ea04b1c80L15-R24))
* `libgsh/src/simple/service.rs`:
  - Similar updates were made to `SimpleService`, removing the static `new` method and converting `server_hello` and `auth_verifier` to instance methods. ([libgsh/src/simple/service.rsL13-R22](diffhunk://#diff-e82d92393bcf8967396092899daca5fdacd80a8e3847d292086bd8983f933605L13-R22))

### Example Updates:

* `examples/colors/src/main.rs`:
  - Replaced the static `new` method with `ColorService::default()` and removed redundant `new` implementation. ([[1]](diffhunk://#diff-a202ebb7f5d38d5e4b95c27e0be37b5b5e82be107b512b5d49721c98e87ddc40L35-R35), [[2]](diffhunk://#diff-a202ebb7f5d38d5e4b95c27e0be37b5b5e82be107b512b5d49721c98e87ddc40R47), [[3]](diffhunk://#diff-a202ebb7f5d38d5e4b95c27e0be37b5b5e82be107b512b5d49721c98e87ddc40L93-R98))
* `examples/cube/src/main.rs`:
  - Updated `CubeService` to implement `Default` for initialization and removed the static `new` method. ([[1]](diffhunk://#diff-5e26ccf4f571b5095a0c5014ca91939c252410b655d356a0c565558f56f701e5L49-R71), [[2]](diffhunk://#diff-5e26ccf4f571b5095a0c5014ca91939c252410b655d356a0c565558f56f701e5L192-R208))
* `examples/password_auth/src/main.rs`:
  - Introduced a constructor `AuthService::new` for initializing with a password and removed the static `new` method. ([[1]](diffhunk://#diff-6e2a4eddcfc829ec24462f345244cfb7ff4e48c1423d378b0402639feaf61e6bL25-R42), [[2]](diffhunk://#diff-6e2a4eddcfc829ec24462f345244cfb7ff4e48c1423d378b0402639feaf61e6bL51-R61))
* `examples/signature_auth/src/main.rs`:
  - Added `Default` implementation for `AuthService` and introduced an `authorize_key` method for managing authorized keys. Updated to use instance methods. ([[1]](diffhunk://#diff-b8a4ad8b948d84db405c84c345ac45434bd4e4b15dba9e9ea8cba0295a91d39eL31-R55), [[2]](diffhunk://#diff-b8a4ad8b948d84db405c84c345ac45434bd4e4b15dba9e9ea8cba0295a91d39eL57-R67), [[3]](diffhunk://#diff-b8a4ad8b948d84db405c84c345ac45434bd4e4b15dba9e9ea8cba0295a91d39eL81-R88))

### Closes
- #34 