### PR TITLE
Update release workflow to install dependencies in a cross-platform way

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-22.04, os_short: "linux", target: x86_64-unknown-linux-gnu, arch: "x64", exe: ""     }
-          - { os: windows-latest, os_short: "win",  target: x86_64-pc-windows-msvc  , arch: "x64", exe: ".exe" }
+          - { os: ubuntu-22.04, os_short: "linux", target: x86_64-unknown-linux-gnu, arch: "x64", exe: "", install_deps: "sudo apt-get update && sudo apt-get install -y protobuf-compiler libpipewire-0.3-dev libxcb1-dev" }
+          - { os: windows-latest, os_short: "win",  target: x86_64-pc-windows-msvc  , arch: "x64", exe: ".exe", install_deps: "" }
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -33,6 +33,10 @@ jobs:
       uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install dependencies
+      if: matrix.install_deps != ''
+      run: ${{ matrix.install_deps }}
 
     - name: Build Client
       run: cargo build -p gsh --release --target ${{ matrix.target }}


### PR DESCRIPTION
Update `release.yml` workflow to install dependencies on Linux in a cross-platform way.

* Add a step to install dependencies on Linux using `sudo apt-get install -y protobuf-compiler libpipewire-0.3-dev libxcb1-dev`.
* Use a matrix strategy to define different steps for different operating systems.
* Ensure the steps are only executed on the appropriate operating system using the `if` condition.
* Add an install command for dependencies in the matrix and if that is set for that particular OS, run it.
* Rename the field from install command to install_deps.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WilliamRagstad/gsh/pull/38?shareId=e4c2ec2d-60d2-42c3-b255-e5b2b65e5ecb).